### PR TITLE
Corrección de horas de trabajo máximas en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Esta es una aplicación de Interfaz de Línea de Comandos (CLI) desarrollada con
 - Un proyecto contiene varias tareas que se pueden delegar a diferentes empleados.
 - El sistema permite a los empleados registrar la cantidad de horas que trabajan en cada tarea específica.
 - Se incluye la funcionalidad para calcular el total de horas invertidas, ya sea filtrando por tarea individual o por proyecto completo.
-- Se agregan validaciones de seguridad para evitar que se ingresen datos erróneos, como impedir que un empleado registre jornadas irreales, como por ejemplo más de 24 horas en un solo día o valores negativos.
+- Se agregan validaciones de seguridad para evitar que se ingresen datos erróneos, como impedir que un empleado registre jornadas irreales, como por ejemplo más de 12 horas en un solo día o valores negativos.
 
 ## Estado del Proyecto
 


### PR DESCRIPTION
# Cambios realizados
- Se modificó el archivo README para indicar que no se permite ingresar más de 12 horas de trabajo, en lugar de 24 horas, para un empleado en un solo día.