### PR TITLE
Corrección de tilde en el comentario del módulo 3

### DIFF
--- a/gestor_proyectos_demo.psc
+++ b/gestor_proyectos_demo.psc
@@ -43,7 +43,7 @@ Algoritmo GestorProyectos
                 FinSi
                 Escribir ""
             2:
-				// Módulo 3 - Visualizacion de datos
+				// Módulo 3 - Visualización de datos
 				Escribir "                                                                       "
 				Escribir "====================== RESUMEN DE ACTIVIDAD ==========================="
 				Escribir " Gestor de proyectos: " nombreProyecto


### PR DESCRIPTION
# Cambios realizados

- Se ha corregido una falta de tilde en el comentario que indica el inicio del módulo 3.