### PR TITLE
docs: Actualizar sección "Instalación y Configuración del Entorno" en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cd gestor-proyectos-cli
   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
   ```
 
-  Esto le indicará a PowerShell que permita la ejecución de scripts para el usuario actual del sistema. Presiona `S` + `Enter` para confirmar, y vuelve a intentar activar el entorno virtual.
+  Esto le indicará a PowerShell que permita la ejecución de scripts para el usuario actual del sistema. Presiona <kbd>S</kbd> + <kbd>Enter</kbd> para confirmar, y vuelve a intentar activar el entorno virtual.
 
 - En Windows (CMD):
 


### PR DESCRIPTION
# Cambios realizados
- Actualización de la sección `Instalación y Configuración del Entorno` en el paso número 3. Se usaron las etiquetas `<kbd>` en lugar de las comillas invertidas, cuando se mencionan las teclas <kbd>S</kbd> y <kbd>Enter</kbd>, para representarlas visualmente no como código sino como teclas.